### PR TITLE
Use --max_file_size=-1 to avoid splitting export files

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -481,6 +481,8 @@ Feature: Export content.
       """
 
   Scenario: Export spliting the dump
+    Given a WP install
+
     When I run `wp export --max_file_size=0.0001`
     Then STDOUT should contain:
       """
@@ -488,6 +490,8 @@ Feature: Export content.
       """
 
   Scenario: Export without spliting the dump
+    Given a WP install
+
     When I run `wp export --max_file_size=-1`
     Then STDOUT should contain:
       """

--- a/features/export.feature
+++ b/features/export.feature
@@ -479,3 +479,21 @@ Feature: Export content.
       """
       0
       """
+
+  Scenario: Export spliting the dump
+    When I run `wp export --max_file_size=0.0001`
+    Then STDOUT should contain:
+      """
+      001.xml
+      """
+
+  Scenario: Export without spliting the dump
+    When I run `wp export --max_file_size=-1`
+    Then STDOUT should contain:
+      """
+      000.xml
+      """
+    And STDOUT should not contain:
+      """
+      001.xml
+      """

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -39,7 +39,7 @@ class Export_Command extends WP_CLI_Command {
 	 * : Don't include comments in the WXR export file.
 	 *
 	 * [--max_file_size=<MB>]
-	 * : A single export file should have this many megabytes.
+	 * : A single export file should have this many megabytes. -1 for unlimited.
 	 * ---
 	 * default: 15
 	 * ---
@@ -169,6 +169,7 @@ class Export_Command extends WP_CLI_Command {
 			define( 'EB_IN_BYTES', 1024 * PB_IN_BYTES );
 			define( 'ZB_IN_BYTES', 1024 * EB_IN_BYTES );
 			define( 'YB_IN_BYTES', 1024 * ZB_IN_BYTES );
+			define( 'WP_EXPORT_NO_SPLIT', -1 );
 		}
 
 		require dirname( dirname( __FILE__ ) ) . '/functions.php';
@@ -382,7 +383,7 @@ class Export_Command extends WP_CLI_Command {
 			return false;
 		}
 
-		$this->max_file_size = $size;
+		$this->max_file_size = $size <= 0 ? WP_EXPORT_NO_SPLIT : $size;
 
 		return true;
 	}

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -383,7 +383,7 @@ class Export_Command extends WP_CLI_Command {
 			return false;
 		}
 
-		$this->max_file_size = $size <= 0 ? WP_EXPORT_NO_SPLIT : $size;
+		$this->max_file_size = $size == -1 ? WP_EXPORT_NO_SPLIT : $size;
 
 		return true;
 	}

--- a/src/WP_Export_Split_Files_Writer.php
+++ b/src/WP_Export_Split_Files_Writer.php
@@ -19,7 +19,8 @@ class WP_Export_Split_Files_Writer extends WP_Export_Base_Writer {
 	public function export() {
 		$this->start_new_file();
 		foreach( $this->formatter->posts() as $post_xml ) {
-			if ( $this->current_file_size + strlen( $post_xml ) > $this->max_file_size ) {
+			if ( $this->max_file_size != WP_EXPORT_NO_SPLIT &&
+					 $this->current_file_size + strlen( $post_xml ) > $this->max_file_size ) {
 				$this->start_new_file();
 			}
 			$this->write( $post_xml );


### PR DESCRIPTION
Fixes #8