### PR TITLE
Add ability to export a WXR to STDOUT

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -522,3 +522,12 @@ Feature: Export content.
       """
       2
       """
+
+  Scenario: Error when --stdout and --dir are both provided
+    Given a WP install
+
+    When I try `wp export --stdout --dir=foo`
+    Then STDERR should be:
+      """
+      Error: --stdout and --dir cannot be used together.
+      """

--- a/features/export.feature
+++ b/features/export.feature
@@ -483,7 +483,13 @@ Feature: Export content.
   Scenario: Export a site to stdout
     Given a WP install
     And I run `wp comment generate --post_id=1 --count=1`
-    When I run `wp export --stdout`
+    And I run `wp plugin install wordpress-importer --activate`
+
+    When I run `wp export --stdout > export.xml`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `cat export.xml`
     Then STDOUT should not contain:
       """
       Writing to file
@@ -491,4 +497,28 @@ Feature: Export content.
     And STDOUT should contain:
       """
       <generator>
+      """
+
+    When I run `wp site empty --yes`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp comment list --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp import export.xml --authors=skip`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp comment list --format=count`
+    Then STDOUT should be:
+      """
+      2
       """

--- a/features/export.feature
+++ b/features/export.feature
@@ -479,3 +479,16 @@ Feature: Export content.
       """
       0
       """
+
+  Scenario: Export a site to stdout
+    Given a WP install
+    And I run `wp comment generate --post_id=1 --count=1`
+    When I run `wp export --stdout`
+    Then STDOUT should not contain:
+      """
+      Writing to file
+      """
+    And STDOUT should contain:
+      """
+      <generator>
+      """

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -208,8 +208,7 @@ class Export_Command extends WP_CLI_Command {
 			}
 		}
 
-		// called last to check possible mutual-exclusion with previous arguments
-		if (isset($args['stdout'])) {
+		if ( $args['stdout'] ) {
 			$this->wxr_path = NULL;
 			$this->stdout = TRUE;
 		}

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -124,7 +124,7 @@ class Export_Command extends WP_CLI_Command {
 
 
 		if (! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {
-			WP_CLI::error( "--stdout and --dir cannot be used together." );
+			WP_CLI::error( '--stdout and --dir cannot be used together.' );
 		}
 
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -34,7 +34,7 @@ class Export_Command extends WP_CLI_Command {
 	 * [--dir=<dirname>]
 	 * : Full path to directory where WXR export files should be stored. Defaults
 	 * to current working directory.
-
+	 *
 	 * [--stdout]
 	 * : Output the whole XML using standard output (incompatible with --dir=)
 	 *
@@ -125,7 +125,6 @@ class Export_Command extends WP_CLI_Command {
 
 		if (! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {
 			WP_CLI::error( "--stdout and --dir cannot be used together." );
-			WP_CLI::halt(1);
 		}
 
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
@@ -150,7 +149,7 @@ class Export_Command extends WP_CLI_Command {
 				wp_export( array(
 					'filters' => $this->export_args,
 					'writer' => 'WP_Export_Stdout_Writer',
-					'writer_args' => array( )
+					'writer_args' => NULL
 				) );
 			} else {
 				wp_export( array(

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -34,6 +34,9 @@ class Export_Command extends WP_CLI_Command {
 	 * [--dir=<dirname>]
 	 * : Full path to directory where WXR export files should be stored. Defaults
 	 * to current working directory.
+
+	 * [--stdout]
+	 * : Output the whole XML using standard output (incompatible with --dir=)
 	 *
 	 * [--skip_comments]
 	 * : Don't include comments in the WXR export file.
@@ -104,6 +107,7 @@ class Export_Command extends WP_CLI_Command {
 	public function __invoke( $_, $assoc_args ) {
 		$defaults = array(
 			'dir'               => NULL,
+			'stdout'            => FALSE,
 			'start_date'        => NULL,
 			'end_date'          => NULL,
 			'post_type'         => NULL,
@@ -118,14 +122,23 @@ class Export_Command extends WP_CLI_Command {
 			'filename_format'   => '{site}.wordpress.{date}.{n}.xml',
 		);
 
+
+		if (! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {
+			WP_CLI::error( "--stdout and --dir cannot be used together." );
+			WP_CLI::halt(1);
+		}
+
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
 		$this->validate_args( $assoc_args );
 
 		if ( !function_exists( 'wp_export' ) ) {
 			self::load_export_api();
 		}
 
-		WP_CLI::log( 'Starting export process...' );
+		if ( ! $this->stdout ) {
+			WP_CLI::log( 'Starting export process...' );
+		}
 
 		add_action( 'wp_export_new_file', function( $file_path ) {
 			WP_CLI::log( sprintf( "Writing to file %s", $file_path ) );
@@ -133,20 +146,30 @@ class Export_Command extends WP_CLI_Command {
 		} );
 
 		try {
-			wp_export( array(
-				'filters' => $this->export_args,
-				'writer' => 'WP_Export_Split_Files_Writer',
-				'writer_args' => array(
-					'max_file_size' => $this->max_file_size * MB_IN_BYTES,
-					'destination_directory' => $this->wxr_path,
-					'filename_template' => self::get_filename_template( $assoc_args['filename_format'] ),
-				)
-			) );
+			if ( $this->stdout ) {
+				wp_export( array(
+					'filters' => $this->export_args,
+					'writer' => 'WP_Export_Stdout_Writer',
+					'writer_args' => array( )
+				) );
+			} else {
+				wp_export( array(
+					'filters' => $this->export_args,
+					'writer' => 'WP_Export_Split_Files_Writer',
+					'writer_args' => array(
+						'max_file_size' => $this->max_file_size * MB_IN_BYTES,
+						'destination_directory' => $this->wxr_path,
+						'filename_template' => self::get_filename_template( $assoc_args['filename_format'] ),
+					)
+				) );
+			}
 		} catch ( Exception $e ) {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		WP_CLI::success( 'All done with export.' );
+		if ( ! $this->stdout ) {
+			WP_CLI::success( 'All done with export.' );
+		}
 	}
 
 	private static function get_filename_template( $filename_format ) {
@@ -183,6 +206,12 @@ class Export_Command extends WP_CLI_Command {
 				if ( false === $result )
 					$has_errors = true;
 			}
+		}
+
+		// called last to check possible mutual-exclusion with previous arguments
+		if (isset($args['stdout'])) {
+			$this->wxr_path = NULL;
+			$this->stdout = TRUE;
 		}
 
 		if ( $has_errors ) {

--- a/src/WP_Export_Stdout_Writer.php
+++ b/src/WP_Export_Stdout_Writer.php
@@ -2,9 +2,8 @@
 
 class WP_Export_Stdout_Writer extends WP_Export_Base_Writer {
 
-	function __construct( $formatter, $writer_args = array() ) {
+	function __construct( $formatter, $writer_args ) {
 		parent::__construct( $formatter );
-		//TODO: check if args are not missing
 		$this->before_posts_xml = $this->formatter->before_posts();
 		$this->after_posts_xml = $this->formatter->after_posts();
 	}

--- a/src/WP_Export_Stdout_Writer.php
+++ b/src/WP_Export_Stdout_Writer.php
@@ -9,7 +9,6 @@ class WP_Export_Stdout_Writer extends WP_Export_Base_Writer {
 	}
 
 	public function export() {
-		// WP_CLI\Utils\wp_clear_object_cache(); ?
 		fwrite( STDOUT, $this->before_posts_xml );
 		foreach( $this->formatter->posts() as $post_xml ) {
 			fwrite( STDOUT, $post_xml );

--- a/src/WP_Export_Stdout_Writer.php
+++ b/src/WP_Export_Stdout_Writer.php
@@ -1,0 +1,22 @@
+<?php
+
+class WP_Export_Stdout_Writer extends WP_Export_Base_Writer {
+
+	function __construct( $formatter, $writer_args = array() ) {
+		parent::__construct( $formatter );
+		//TODO: check if args are not missing
+		$this->before_posts_xml = $this->formatter->before_posts();
+		$this->after_posts_xml = $this->formatter->after_posts();
+	}
+
+	public function export() {
+		// WP_CLI\Utils\wp_clear_object_cache(); ?
+		fwrite( STDOUT, $this->before_posts_xml );
+		foreach( $this->formatter->posts() as $post_xml ) {
+			fwrite( STDOUT, $post_xml );
+		}
+		fwrite( STDOUT, $this->after_posts_xml );
+	}
+
+	protected function write( $xml ) { }
+}


### PR DESCRIPTION
Ability to export to _stdout_.
Sorry for the lack of testing (yet), but having I didn't find a way to use my common `wp` phar file while overriding the `export` using the git local copy.
Neither `requir`'ing in `wp-config.php`, neither `wp --require=` made it (hint welcome)

Fixes #9