### PR TITLE
support exporting attachments when specific post ids are requested

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -142,6 +142,20 @@ Feature: Export content.
       11
       """
 
+    When I run `wp post create --post_title='Post with attachment' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ATTACHMENT_POST_ID}
+
+    When I run `wp post create --post_type=attachment --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ATTACHMENT_ID}
+
+    When I run `wp post update {ATTACHMENT_ID} --post_parent={ATTACHMENT_POST_ID} --porcelain`
+    Then STDOUT should contain:
+      """
+      Success: Updated post {ATTACHMENT_ID}
+      """
+
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {POST_ID}
@@ -166,6 +180,12 @@ Feature: Export content.
     Then STDOUT should be:
       """
       1
+      """
+
+    When I run `wp post list --post_type=attachment --format=count`
+    Then STDOUT should be:
+      """
+      0
       """
 
     When I run `wp comment list --format=count`

--- a/features/export.feature
+++ b/features/export.feature
@@ -666,7 +666,7 @@ Feature: Export content.
       """
 
     When I run `wp export --post__in={EXPORT_ATTACHMENT_POST_ID} --with_attachments`
-    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    Then save STDOUT 'Writing to file %s' as {EXPORT_FILE}
 
     When I run `wp site empty --yes`
     Then STDOUT should not be empty

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -150,6 +150,12 @@ class Export_Command extends WP_CLI_Command {
 
 		$this->validate_args( $assoc_args );
 
+		$this->export_args['with_attachments'] = WP_CLI\Utils\get_flag_value(
+			$assoc_args,
+			'with_attachments',
+			$defaults['with_attachments']
+		);
+
 		if ( !function_exists( 'wp_export' ) ) {
 			self::load_export_api();
 		}
@@ -318,18 +324,6 @@ class Export_Command extends WP_CLI_Command {
 		}
 		// New exporter uses a different argument.
 		$this->export_args['post_ids'] = $post__in;
-		return true;
-	}
-
-	private function check_with_attachments( $with ) {
-		if ( is_null( $with ) )
-			return true;
-
-		if ( (int) $with <> 0 && (int) $with <> 1 ) {
-			WP_CLI::warning( 'with_attachments needs to be 0 (no) or 1 (yes).' );
-			return false;
-		}
-		$this->export_args['with_attachments'] = ((int) $with) == 1 ;
 		return true;
 	}
 


### PR DESCRIPTION
support exporting attachments when specific post ids are requested (assuming the post whose ids were specified were not attachment themselves)

`getenv()` to limit merge-conflict with other pending PR + fact that there may be long debates about how to pass the option, eg: `--attachments` / `--force-attachment` / `--post__in=+<num>,-<num>,...` / `--with-deps` / ...