### PR TITLE
Convert the export command help summary to use a third-person singular verb.

### DIFF
--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -29,7 +29,7 @@ class Export_Command extends WP_CLI_Command {
 	private $wxr_path;
 
 	/**
-	 * Export WordPress content to a WXR file.
+	 * Exports WordPress content to a WXR file.
 	 *
 	 * Generates one or more WXR files containing authors, terms, posts,
 	 * comments, and attachments. WXR files do not include site configuration


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts the help summary for the export command to use a third-person singular verb.