### PR TITLE
Add apply_filters to calculate_post_ids function

### DIFF
--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -33,7 +33,7 @@ class WP_Export_Query {
 
 	public function __construct( $filters = array() ) {
 		$this->filters = wp_parse_args( $filters, self::$defaults );
-		$this->post_ids = $this->calculate_post_ids();
+		$this->post_ids = apply_filters( 'wxr_export_calculate_post_ids', $this->calculate_post_ids() );
 	}
 
 	public function post_ids() {


### PR DESCRIPTION
Sometimes I find myself wanting to add post ids to export that are not easy to include via the cli arguments. For example if I a post exists that has a acf gallery field I want to include the post ids of the attachments in the gallery field as I can't guarantee they are attachments on the post itself.