### PR TITLE
create <wp:category> elements for custom taxonomy as well

### DIFF
--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -88,6 +88,10 @@ class WP_Export_Query {
 		return $categories;
 	}
 
+	public function custom_taxonomies() {
+		return get_taxonomies( array( '_builtin' => false ), 'objects' );
+	}
+
 	public function tags() {
 		if ( $this->filters['post_type'] ) {
 			return array();

--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -23,6 +23,7 @@ class WP_Export_WXR_Formatter {
 		$before_posts_xml .= $this->site_metadata();
 		$before_posts_xml .= $this->authors();
 		$before_posts_xml .= $this->categories();
+		$before_posts_xml .= $this->custom_taxonomies();
 		$before_posts_xml .= $this->tags();
 		$before_posts_xml .= $this->nav_menu_terms();
 		$before_posts_xml .= $this->custom_taxonomies_terms();
@@ -122,6 +123,19 @@ COMMENT;
 				->tag( 'wp:category_parent', $category->parent_slug )
 				->optional_cdata( 'wp:cat_name', $category->name )
 				->optional_cdata( 'wp:category_description', $category->description )
+				->end;
+		}
+		return $oxymel->to_string();
+	}
+
+	public function custom_taxonomies() {
+		$oxymel = new WP_Export_Oxymel;
+		$custom_taxonomies = $this->export->custom_taxonomies();
+		foreach( $custom_taxonomies as $taxonomy ) {
+			$oxymel->tag( 'wp:category' )->contains
+				->tag( 'wp:category_nicename', $taxonomy->name )
+				->optional_cdata( 'wp:cat_name', $taxonomy->label )
+				->optional_cdata( 'wp:category_description', $taxonomy->description )
 				->end;
 		}
 		return $oxymel->to_string();


### PR DESCRIPTION
As it's already done for the default one ("category").

Importer only considers custom taxonomy terms if a `<wp:category>` [exists for the taxonomy](https://github.com/humanmade/WordPress-Importer/blob/master/class-wxr-importer.php#L410) they belong to but exporter does not create them.

Mentioning @sudar since he may have experienced a similar concern too in #42 