### PR TITLE
make load_export_api() public

### DIFF
--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -213,7 +213,7 @@ class Export_Command extends WP_CLI_Command {
 		return str_replace( [ '{site}', '{date}', '{n}' ], [ $sitename, date( 'Y-m-d' ), '%03d' ], $filename_format );
 	}
 
-	private static function load_export_api() {
+	public static function load_export_api() {
 		require dirname( dirname( __FILE__ ) ) . '/functions.php';
 	}
 


### PR DESCRIPTION
When reusing the export command, a call to `load_export_api()` is needed to avoid
`undefined function _wp_export_build_IN_condition()`

Sample code:
```php
  $args = ['with_attachments' => FALSE, 'post_ids' => [1,2,3]];
  Export_Command::load_export_api(); // <--- here
  (new WP_Export_Stdout_Writer(new WP_Export_WXR_Formatter(new WP_Export_Query($args)), null))->export();
```