### PR TITLE
Allow to opt-out from dump specific sections

### DIFF
--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -17,16 +17,41 @@ class WP_Export_WXR_Formatter {
 		$this->wxr_version = WXR_VERSION;
 	}
 
-	public function before_posts() {
+	public function before_posts( $opts = [] ) {
 		$before_posts_xml  = '';
-		$before_posts_xml .= $this->header();
-		$before_posts_xml .= $this->site_metadata();
-		$before_posts_xml .= $this->authors();
-		$before_posts_xml .= $this->categories();
-		$before_posts_xml .= $this->tags();
-		$before_posts_xml .= $this->nav_menu_terms();
-		$before_posts_xml .= $this->custom_taxonomies_terms();
-		$before_posts_xml .= $this->rss2_head_action();
+
+		if ( !$opts || in_array( 'header', $opts, true ) ) {
+			$before_posts_xml .= $this->header();
+		}
+
+		if ( !$opts || in_array( 'site_metadata', $opts, true ) ) {
+			$before_posts_xml .= $this->site_metadata();
+		}
+
+		if ( !$opts || in_array( 'authors', $opts, true ) ) {
+			$before_posts_xml .= $this->authors();
+		}
+
+		if ( !$opts || in_array( 'categories', $opts, true ) ) {
+			$before_posts_xml .= $this->categories();
+		}
+
+		if ( !$opts || in_array( 'tags', $opts, true ) ) {
+			$before_posts_xml .= $this->tags();
+		}
+
+		if ( !$opts || in_array( 'nav_menu_terms', $opts, true ) ) {
+			$before_posts_xml .= $this->nav_menu_terms();
+		}
+
+		if ( !$opts || in_array( 'custom_taxonomies_terms', $opts, true ) ) {
+			$before_posts_xml .= $this->custom_taxonomies_terms();
+		}
+
+		if ( !$opts || in_array( 'rss2_head_action', $opts, true ) ) {
+			$before_posts_xml .= $this->rss2_head_action();
+}
+
 		return $before_posts_xml;
 	}
 

--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -29,7 +29,7 @@ class WP_Export_WXR_Formatter {
 			'rss2_head_action',
 		];
 
-		$before_posts_xml  = '';
+		$before_posts_xml = '';
 
 		foreach ( $available_sections as $section ) {
 			if ( ! $requested_sections || in_array( $section, $requested_sections, true ) ) {

--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -17,40 +17,25 @@ class WP_Export_WXR_Formatter {
 		$this->wxr_version = WXR_VERSION;
 	}
 
-	public function before_posts( $opts = [] ) {
+	public function before_posts( $requested_sections = [] ) {
+		$available_sections = [
+			'header',
+			'site_metadata',
+			'authors',
+			'categories',
+			'tags',
+			'nav_menu_terms',
+			'custom_taxonomies_terms',
+			'rss2_head_action',
+		];
+
 		$before_posts_xml  = '';
 
-		if ( !$opts || in_array( 'header', $opts, true ) ) {
-			$before_posts_xml .= $this->header();
+		foreach ( $available_sections as $section ) {
+			if ( !$requested_sections || in_array( $section, $requested_sections, true ) ) {
+				$before_posts_xml .= $this->$section();
+			}
 		}
-
-		if ( !$opts || in_array( 'site_metadata', $opts, true ) ) {
-			$before_posts_xml .= $this->site_metadata();
-		}
-
-		if ( !$opts || in_array( 'authors', $opts, true ) ) {
-			$before_posts_xml .= $this->authors();
-		}
-
-		if ( !$opts || in_array( 'categories', $opts, true ) ) {
-			$before_posts_xml .= $this->categories();
-		}
-
-		if ( !$opts || in_array( 'tags', $opts, true ) ) {
-			$before_posts_xml .= $this->tags();
-		}
-
-		if ( !$opts || in_array( 'nav_menu_terms', $opts, true ) ) {
-			$before_posts_xml .= $this->nav_menu_terms();
-		}
-
-		if ( !$opts || in_array( 'custom_taxonomies_terms', $opts, true ) ) {
-			$before_posts_xml .= $this->custom_taxonomies_terms();
-		}
-
-		if ( !$opts || in_array( 'rss2_head_action', $opts, true ) ) {
-			$before_posts_xml .= $this->rss2_head_action();
-}
 
 		return $before_posts_xml;
 	}

--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -32,7 +32,7 @@ class WP_Export_WXR_Formatter {
 		$before_posts_xml  = '';
 
 		foreach ( $available_sections as $section ) {
-			if ( !$requested_sections || in_array( $section, $requested_sections, true ) ) {
+			if ( ! $requested_sections || in_array( $section, $requested_sections, true ) ) {
 				$before_posts_xml .= $this->$section();
 			}
 		}


### PR DESCRIPTION
Let the formatter know about which WXR sections one requires.
Default is still to dump everything, but callee may opt-out from, eg, authors or tags.
