### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -75,3 +78,7 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -210,7 +210,7 @@ class Export_Command extends WP_CLI_Command {
 		if ( empty( $sitename ) ) {
 			$sitename = 'site';
 		}
-		return str_replace( [ '{site}', '{date}', '{n}' ], [ $sitename, date( 'Y-m-d' ), '%03d' ], $filename_format );
+		return str_replace( [ '{site}', '{date}', '{n}' ], [ $sitename, date( 'Y-m-d' ), '%03d' ], $filename_format ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 	}
 
 	public static function load_export_api() {
@@ -263,7 +263,7 @@ class Export_Command extends WP_CLI_Command {
 			WP_CLI::warning( sprintf( 'The start_date %s is invalid.', $date ) );
 			return false;
 		}
-		$this->export_args['start_date'] = date( 'Y-m-d', $time );
+		$this->export_args['start_date'] = date( 'Y-m-d', $time ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		return true;
 	}
 
@@ -277,7 +277,7 @@ class Export_Command extends WP_CLI_Command {
 			WP_CLI::warning( sprintf( 'The end_date %s is invalid.', $date ) );
 			return false;
 		}
-		$this->export_args['end_date'] = date( 'Y-m-d', $time );
+		$this->export_args['end_date'] = date( 'Y-m-d', $time ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		return true;
 	}
 

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -53,7 +53,7 @@ class WP_Export_Query {
 			'url'         => $this->bloginfo_rss( 'url' ),
 			'language'    => $this->bloginfo_rss( 'language' ),
 			'description' => $this->bloginfo_rss( 'description' ),
-			'pubDate'     => date( 'D, d M Y H:i:s +0000' ),
+			'pubDate'     => date( 'D, d M Y H:i:s +0000' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 			'site_url'    => is_multisite() ? network_home_url() : $this->bloginfo_rss( 'url' ),
 			'blog_url'    => $this->bloginfo_rss( 'url' ),
 		);
@@ -239,7 +239,7 @@ class WP_Export_Query {
 		if ( ! $timestamp ) {
 			return;
 		}
-		$this->wheres[] = $wpdb->prepare( 'p.post_date >= %s', date( 'Y-m-d 00:00:00', $timestamp ) );
+		$this->wheres[] = $wpdb->prepare( 'p.post_date >= %s', date( 'Y-m-d 00:00:00', $timestamp ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 	}
 
 	private function end_date_where() {
@@ -252,7 +252,7 @@ class WP_Export_Query {
 		if ( ! $timestamp ) {
 			return;
 		}
-		$this->wheres[] = $wpdb->prepare( 'p.post_date <= %s', date( 'Y-m-d 23:59:59', $timestamp ) );
+		$this->wheres[] = $wpdb->prepare( 'p.post_date <= %s', date( 'Y-m-d 23:59:59', $timestamp ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 	}
 
 	private function start_id_where() {


### PR DESCRIPTION
The testing step for PHP 7.4 is still allowed to fail for now while we prepare the code base for the upcoming release.