### PR TITLE
Add the_title_export filter and cdata for item title to export

### DIFF
--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -175,7 +175,7 @@ COMMENT;
 		setup_postdata( $post );
 
 		$oxymel->item->contains
-			->title( apply_filters( 'the_title_rss', $post->post_title ) ) // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress native hook.
+			->tag( 'title' )->contains->cdata( apply_filters( 'the_title_export', $post->post_title ) )->end // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress native hook.
 			->link( esc_url( apply_filters( 'the_permalink_rss', get_permalink() ) ) ) // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress native hook.
 			->pubDate( mysql2date( 'D, d M Y H:i:s +0000', get_post_time( 'Y-m-d H:i:s', true ), false ) )
 			->tag( 'dc:creator', get_the_author_meta( 'login' ) )


### PR DESCRIPTION
Adds the new the_title_export filter and cdata enclosure for item title to the WXR format.

Related core ticket: https://core.trac.wordpress.org/ticket/52250