### PR TITLE
Improve type handling and remove unused variables

### DIFF
--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -168,7 +168,7 @@ class Export_Command extends WP_CLI_Command {
 
 		add_action(
 			'wp_export_new_file',
-			function( $file_path ) {
+			static function ( $file_path ) {
 				WP_CLI::log( sprintf( 'Writing to file %s', $file_path ) );
 				Utils\wp_clear_object_cache();
 			}
@@ -214,7 +214,7 @@ class Export_Command extends WP_CLI_Command {
 	}
 
 	public static function load_export_api() {
-		require dirname( dirname( __FILE__ ) ) . '/functions.php';
+		require dirname( __DIR__ ) . '/functions.php';
 	}
 
 	private function validate_args( $args ) {
@@ -313,7 +313,6 @@ class Export_Command extends WP_CLI_Command {
 		$post_type  = array_unique( array_filter( explode( ',', $post_type ) ) );
 		$post_types = get_post_types();
 
-		$keep_post_types = [];
 		foreach ( $post_type as $type ) {
 			if ( ! in_array( $type, $post_types, true ) ) {
 				WP_CLI::warning(
@@ -351,7 +350,7 @@ class Export_Command extends WP_CLI_Command {
 			return true;
 		}
 
-		$start_id = intval( $start_id );
+		$start_id = (int) $start_id;
 
 		// Post IDs must be greater than 0.
 		if ( 0 >= $start_id ) {
@@ -371,7 +370,7 @@ class Export_Command extends WP_CLI_Command {
 		// phpcs:ignore WordPress.WP.DeprecatedFunctions.get_users_of_blogFound -- Fallback.
 		$authors = function_exists( 'get_users' ) ? get_users() : get_users_of_blog();
 		if ( empty( $authors ) || is_wp_error( $authors ) ) {
-			WP_CLI::warning( sprintf( 'Could not find any authors in this blog.' ) );
+			WP_CLI::warning( 'Could not find any authors in this blog.' );
 			return false;
 		}
 		$hit = false;
@@ -398,7 +397,7 @@ class Export_Command extends WP_CLI_Command {
 
 	private function check_max_num_posts( $num ) {
 		if ( null !== $num && ( ! is_numeric( $num ) || $num <= 0 ) ) {
-			WP_CLI::warning( sprintf( 'max_num_posts should be a positive integer.', $num ) );
+			WP_CLI::warning( 'max_num_posts should be a positive integer.' );
 			return false;
 		}
 
@@ -455,7 +454,7 @@ class Export_Command extends WP_CLI_Command {
 
 	private function check_max_file_size( $size ) {
 		if ( ! is_numeric( $size ) ) {
-			WP_CLI::warning( sprintf( 'max_file_size should be numeric.', $size ) );
+			WP_CLI::warning( 'max_file_size should be numeric.' );
 			return false;
 		}
 

--- a/src/WP_Export_File_Writer.php
+++ b/src/WP_Export_File_Writer.php
@@ -18,8 +18,10 @@ class WP_Export_File_Writer extends WP_Export_Base_Writer {
 		try {
 			parent::export();
 		} catch ( WP_Export_Exception $e ) {
+			fclose( $this->f );
 			throw $e;
 		} catch ( WP_Export_Term_Exception $e ) {
+			fclose( $this->f );
 			throw $e;
 		}
 
@@ -29,7 +31,7 @@ class WP_Export_File_Writer extends WP_Export_Base_Writer {
 	protected function write( $xml ) {
 		$res = fwrite( $this->f, $xml );
 		if ( false === $res ) {
-			throw new WP_Export_Exception( __( 'WP Export: error writing to export file.' ) );
+			throw new WP_Export_Exception( 'WP Export: error writing to export file.' );
 		}
 	}
 }

--- a/src/WP_Export_Oxymel.php
+++ b/src/WP_Export_Oxymel.php
@@ -2,21 +2,21 @@
 
 class WP_Export_Oxymel extends Oxymel {
 	public function optional( $tag_name, $contents ) {
-		if ( $contents ) {
+		if ( ( property_exists( $this, $tag_name ) || method_exists( $this, $tag_name ) ) && $contents ) {
 			$this->$tag_name( $contents );
 		}
 		return $this;
 	}
 
 	public function optional_cdata( $tag_name, $contents ) {
-		if ( $contents ) {
+		if ( property_exists( $this, $tag_name ) && is_object( $this->$tag_name ) && $contents ) {
 			$this->$tag_name->contains->cdata( $contents )->end;
 		}
 		return $this;
 	}
 
 	public function cdata( $text ) {
-		if ( ! seems_utf8( $text ) ) {
+		if ( is_string( $text ) && ! seems_utf8( $text ) ) {
 			$text = utf8_encode( $text );
 		}
 		return parent::cdata( $text );

--- a/src/WP_Export_Split_Files_Writer.php
+++ b/src/WP_Export_Split_Files_Writer.php
@@ -48,7 +48,7 @@ class WP_Export_Split_Files_Writer extends WP_Export_Base_Writer {
 	protected function write( $xml ) {
 		$res = fwrite( $this->f, $xml );
 		if ( false === $res ) {
-			throw new WP_Export_Exception( __( 'WP Export: error writing to export file.' ) );
+			throw new WP_Export_Exception( 'WP Export: error writing to export file.' );
 		}
 		$this->current_file_size += strlen( $xml );
 	}

--- a/src/WP_Export_WXR_Formatter.php
+++ b/src/WP_Export_WXR_Formatter.php
@@ -41,7 +41,7 @@ class WP_Export_WXR_Formatter {
 	}
 
 	public function posts() {
-		return new WP_Map_Iterator( $this->export->posts(), array( $this, 'post' ) );
+		return new WP_Map_Iterator( $this->export->posts(), [ $this, 'post' ] );
 	}
 
 	public function after_posts() {
@@ -50,7 +50,6 @@ class WP_Export_WXR_Formatter {
 
 	public function header() {
 		$oxymel           = new Oxymel();
-		$charset          = $this->export->charset();
 		$wp_generator_tag = $this->export->wp_generator_tag();
 		$comment          = <<<COMMENT
 
@@ -77,14 +76,14 @@ COMMENT;
 			->comment( $comment )
 			->raw( $wp_generator_tag )
 			->open_rss(
-				array(
+				[
 					'version'       => '2.0',
 					'xmlns:excerpt' => "http://wordpress.org/export/{$this->wxr_version}/excerpt/",
 					'xmlns:content' => 'http://purl.org/rss/1.0/modules/content/',
 					'xmlns:wfw'     => 'http://wellformedweb.org/CommentAPI/',
 					'xmlns:dc'      => 'http://purl.org/dc/elements/1.1/',
 					'xmlns:wp'      => "http://wordpress.org/export/{$this->wxr_version}/",
-				)
+				]
 			)
 				->open_channel
 				->to_string();
@@ -126,7 +125,7 @@ COMMENT;
 	public function categories() {
 		$oxymel     = new WP_Export_Oxymel();
 		$categories = $this->export->categories();
-		foreach ( $categories as $term_id => $category ) {
+		foreach ( $categories as $category ) {
 			$category->parent_slug = $category->parent ? $categories[ $category->parent ]->slug : '';
 			$oxymel->tag( 'wp:category' )->contains
 				->tag( 'wp:term_id', $category->term_id )
@@ -165,8 +164,7 @@ COMMENT;
 		ob_start();
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress native hook.
 		do_action( 'rss2_head' );
-		$action_output = ob_get_clean();
-		return $action_output;
+		return ob_get_clean();
 	}
 
 	public function post( $post ) {
@@ -181,7 +179,7 @@ COMMENT;
 			->link( esc_url( apply_filters( 'the_permalink_rss', get_permalink() ) ) ) // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress native hook.
 			->pubDate( mysql2date( 'D, d M Y H:i:s +0000', get_post_time( 'Y-m-d H:i:s', true ), false ) )
 			->tag( 'dc:creator', get_the_author_meta( 'login' ) )
-			->guid( esc_url( get_the_guid() ), array( 'isPermaLink' => 'false' ) )
+			->guid( esc_url( get_the_guid() ), [ 'isPermaLink' => 'false' ] )
 			->description( '' )
 			->tag( 'content:encoded' )->contains->cdata( $post->post_content )->end
 			->tag( 'excerpt:encoded' )->contains->cdata( $post->post_excerpt )->end
@@ -203,10 +201,10 @@ COMMENT;
 		foreach ( $post->terms as $term ) {
 			$oxymel
 			->category(
-				array(
+				[
 					'domain'   => $term->taxonomy,
 					'nicename' => $term->slug,
-				)
+				]
 			)->contains->cdata( $term->name )->end;
 		}
 		foreach ( $post->meta as $meta ) {

--- a/src/WP_Export_XML_Over_HTTP.php
+++ b/src/WP_Export_XML_Over_HTTP.php
@@ -17,12 +17,12 @@ class WP_Export_XML_Over_HTTP extends WP_Export_Base_Writer {
 		} catch ( WP_Export_Exception $e ) {
 			// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Possibly used by third party extension.
 			$message = apply_filters( 'export_error_message', $e->getMessage() );
-			wp_die( $message, __( 'Export Error' ), array( 'back_link' => true ) );
+			wp_die( $message, __( 'Export Error' ), [ 'back_link' => true ] );
 		} catch ( WP_Export_Term_Exception $e ) {
 			do_action( 'export_term_orphaned', $this->formatter->export->missing_parents );
 			$message = apply_filters( 'export_term_error_message', $e->getMessage() );
 			// phpcs:enable
-			wp_die( $message, __( 'Export Error' ), array( 'back_link' => true ) );
+			wp_die( $message, __( 'Export Error' ), [ 'back_link' => true ] );
 		}
 	}
 

--- a/src/WP_Post_IDs_Iterator.php
+++ b/src/WP_Post_IDs_Iterator.php
@@ -53,10 +53,10 @@ class WP_Post_IDs_Iterator implements Iterator {
 	private function load_next_posts_from_db() {
 		$next_batch_post_ids = array_splice( $this->ids_left, 0, $this->limit );
 		$in_post_ids_sql     = _wp_export_build_IN_condition( 'ID', $next_batch_post_ids );
-		$this->results       = $this->db->get_results( "SELECT * FROM {$this->db->posts} WHERE $in_post_ids_sql" );
+		$this->results       = $this->db->get_results( "SELECT * FROM {$this->db->posts} WHERE {$in_post_ids_sql}" );
 		if ( ! $this->results ) {
 			if ( $this->db->last_error ) {
-				throw new WP_Iterator_Exception( 'Database error: ' . $this->db->last_error );
+				throw new WP_Iterator_Exception( "Database error: {$this->db->last_error}" );
 			} else {
 				return false;
 			}


### PR DESCRIPTION
This PR adds a few minor tweaks in terms of code correctness.

Most importantly, it fixes an issue that might lead to the following notice:

```
PHP Warning:  Trying to access array offset on value of type int in /wp-includes/formatting.php on line 884
```

Related https://github.com/wp-cli/wp-cli/issues/5479