### PR TITLE
Fix category, tag and term names missing in export

### DIFF
--- a/src/WP_Export_Oxymel.php
+++ b/src/WP_Export_Oxymel.php
@@ -11,8 +11,6 @@ class WP_Export_Oxymel extends Oxymel {
 	public function optional_cdata( $tag_name, $contents ) {
 		if ( $contents ) {
 			$this->$tag_name->contains->cdata( $contents )->end;
-		} elseif ( is_string( $tag_name ) && $contents ) {
-
 		}
 		return $this;
 	}

--- a/src/WP_Export_Oxymel.php
+++ b/src/WP_Export_Oxymel.php
@@ -2,15 +2,17 @@
 
 class WP_Export_Oxymel extends Oxymel {
 	public function optional( $tag_name, $contents ) {
-		if ( ( property_exists( $this, $tag_name ) || method_exists( $this, $tag_name ) ) && $contents ) {
+		if ( $contents ) {
 			$this->$tag_name( $contents );
 		}
 		return $this;
 	}
 
 	public function optional_cdata( $tag_name, $contents ) {
-		if ( property_exists( $this, $tag_name ) && is_object( $this->$tag_name ) && $contents ) {
+		if ( $contents ) {
 			$this->$tag_name->contains->cdata( $contents )->end;
+		} elseif ( is_string( $tag_name ) && $contents ) {
+
 		}
 		return $this;
 	}


### PR DESCRIPTION
A regression was introduced with https://github.com/wp-cli/export-command/pull/84 which was reported via #85.

The regression caused the `cat_name`, `tag_name` and `term_name` values to be missing in the generated export.

This PR removes the specific hardening that has introduced this regression, and adds a test scenario to ensure this will not happen again in the future.

Fixes #85