### PR TITLE
Allow a category ID to be passed in the --category filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 ## Using
 
 ~~~
-wp export [--dir=<dirname>] [--stdout] [--skip_comments] [--max_file_size=<MB>] [--start_date=<date>] [--end_date=<date>] [--post_type=<post-type>] [--post_type__not_in=<post-type>] [--post__in=<pid>] [--with_attachments] [--start_id=<pid>] [--max_num_posts=<num>] [--author=<author>] [--category=<name>] [--post_status=<status>] [--filename_format=<format>]
+wp export [--dir=<dirname>] [--stdout] [--skip_comments] [--max_file_size=<MB>] [--start_date=<date>] [--end_date=<date>] [--post_type=<post-type>] [--post_type__not_in=<post-type>] [--post__in=<pid>] [--with_attachments] [--start_id=<pid>] [--max_num_posts=<num>] [--author=<author>] [--category=<name|id>] [--post_status=<status>] [--filename_format=<format>]
 ~~~
 
 Generates one or more WXR files containing authors, terms, posts,
@@ -70,7 +70,7 @@ comments, and attachments. WXR files do not include site configuration
 	[--author=<author>]
 		Export only posts by this author. Can be either user login or user ID.
 
-	[--category=<name>]
+	[--category=<name|id>]
 		Export only posts in this category.
 
 	[--post_status=<status>]

--- a/features/export.feature
+++ b/features/export.feature
@@ -313,6 +313,25 @@ Feature: Export content.
       <![CDATA[Pear Post]]>
       """
 
+    When I run `wp export --post_type=post --category={PEAR_TERM_ID}`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    Then the {EXPORT_FILE} file should contain:
+      """
+      <category domain="category" nicename="pear"><![CDATA[Pear]]></category>
+      """
+    And the {EXPORT_FILE} file should contain:
+      """
+      <![CDATA[Pear Post]]>
+      """
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <category domain="category" nicename="apple"><![CDATA[Apple]]></category>
+      """
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <![CDATA[Apple Post]]>
+      """
+
     When I run `wp site empty --yes`
     Then STDOUT should not be empty
 
@@ -328,11 +347,11 @@ Feature: Export content.
     When I run `wp post list --post_type=post`
     Then STDOUT should contain:
       """
-      Apple Post
+      Pear Post
       """
     And STDOUT should not contain:
       """
-      Pear Post
+      Apple Post
       """
 
   Scenario: Export posts from a given author

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -91,7 +91,7 @@ class Export_Command extends WP_CLI_Command {
 	 * [--author=<author>]
 	 * : Export only posts by this author. Can be either user login or user ID.
 	 *
-	 * [--category=<name>]
+	 * [--category=<name|id>]
 	 * : Export only posts in this category.
 	 *
 	 * [--post_status=<status>]
@@ -409,6 +409,10 @@ class Export_Command extends WP_CLI_Command {
 	private function check_category( $category ) {
 		if ( null === $category ) {
 			return true;
+		}
+
+		if ( is_numeric( $category ) ) {
+			$category = (int) $category;
 		}
 
 		$term = category_exists( $category );


### PR DESCRIPTION
When passing a category ID in the `--category` filter, the export will fail with the following error message:

`Warning: Could not find a category matching 12345.`

This PR fixes it by checking if the category is numeric, and casting it to an `int`.