### PR TITLE
Fix test for attachment serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/features/export.feature
+++ b/features/export.feature
@@ -813,7 +813,7 @@ Feature: Export content.
       """
     And the {EXPORT_FILE} file should contain:
       """
-      codeispoetry.png";s:5:"sizes"
+      codeispoetry.png";s:
       """
     And the {EXPORT_FILE} file should contain:
       """
@@ -841,7 +841,7 @@ Feature: Export content.
       """
     And the {EXPORT_FILE} file should not contain:
       """
-      white-150-square.jpg";s:5:"sizes"
+      white-150-square.jpg";s:
       """
 
   Scenario: Export categories, tags and terms


### PR DESCRIPTION
With WP 6.0, the filesize for attachments was added, which changes the serialization string for the attachments.

This PR makes the test for attachment serialization more flexible.