### PR TITLE
Exclude unnecessary author ids from oembed_cache posts in export

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -986,6 +986,7 @@ Feature: Export content.
       Europe
       """
 
+  @require-wp-5.2
   Scenario: Export posts should not include oembed_cache posts user information
     Given a WP install
     And I run `wp plugin install wordpress-importer --activate`

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -80,7 +80,7 @@ class WP_Export_Query {
 		}
 
 		$authors    = [];
-		$author_ids = (array) $wpdb->get_col( "SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_status != 'auto-draft' and post_type != 'oembed_cache'" );
+		$author_ids = (array) $wpdb->get_col( "SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_status != 'auto-draft' AND post_type != 'oembed_cache'" );
 		foreach ( $author_ids as $author_id ) {
 			$authors[] = get_userdata( $author_id );
 		}

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -80,7 +80,7 @@ class WP_Export_Query {
 		}
 
 		$authors    = [];
-		$author_ids = (array) $wpdb->get_col( "SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_status != 'auto-draft'" );
+		$author_ids = (array) $wpdb->get_col( "SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_status != 'auto-draft' and post_type != 'oembed_cache'" );
 		foreach ( $author_ids as $author_id ) {
 			$authors[] = get_userdata( $author_id );
 		}


### PR DESCRIPTION
This PR is trying to exclude unnecessary author ids from `oembed_cache` posts in export.

Fixes #98 