### PR TITLE
Add `--include_once=<section>` parameter for before_posts data in multi-file exports

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -652,12 +652,46 @@ Feature: Export content.
   Scenario: Export splitting the dump
     Given a WP install
 
-    When I run `wp export --max_file_size=0.0001`
+    When I run `wp export --max_file_size=0.0001 --filename_format='{n}.xml'`
     Then STDOUT should contain:
       """
       001.xml
       """
     And STDERR should be empty
+
+    When I run `cat 000.xml`
+    Then STDOUT should contain:
+      """
+      <wp:category>
+      """
+
+    When I run `cat 001.xml`
+    Then STDOUT should contain:
+      """
+      <wp:category>
+      """
+
+  Scenario: Export splitting the dump with --include_once
+    Given a WP install
+
+    When I run `wp export --max_file_size=0.0001 --include_once=categories --filename_format='{n}.xml'`
+    Then STDOUT should contain:
+      """
+      001.xml
+      """
+    And STDERR should be empty
+
+    When I run `cat 000.xml`
+    Then STDOUT should contain:
+      """
+      <wp:category>
+      """
+
+    When I run `cat 001.xml`
+    Then STDOUT should not contain:
+      """
+      <wp:category>
+      """
 
   Scenario: Export without splitting the dump
     Given a WP install

--- a/features/export.feature
+++ b/features/export.feature
@@ -682,8 +682,19 @@ Feature: Export content.
       <wp:category>
       """
 
-  Scenario: Export splitting the dump with --include_once
+  Scenario: Export splitting the dump with a bad --include_once value
     Given a WP install
+    And I run `wp term generate post_tag --count=1`
+
+    When I try `wp export --max_file_size=0.0001 --include_once=invalid --filename_format='{n}.xml'`
+    Then STDERR should contain:
+      """
+      Warning: include_once should be comma-separated values for optional before_posts sections
+      """
+
+  Scenario: Export splitting the dump with a single --include_once value
+    Given a WP install
+    And I run `wp term generate post_tag --count=1`
 
     When I run `wp export --max_file_size=0.0001 --include_once=categories --filename_format='{n}.xml'`
     Then STDOUT should contain:
@@ -697,11 +708,50 @@ Feature: Export content.
       """
       <wp:category>
       """
+    And STDOUT should contain:
+      """
+      <wp:tag>
+      """
 
     When I run `cat 001.xml`
     Then STDOUT should not contain:
       """
       <wp:category>
+      """
+    And STDOUT should contain:
+      """
+      <wp:tag>
+      """
+
+  Scenario: Export splitting the dump with multiple --include_once values
+    Given a WP install
+    And I run `wp term generate post_tag --count=1`
+
+    When I run `wp export --max_file_size=0.0001 --include_once=categories,tags --filename_format='{n}.xml'`
+    Then STDOUT should contain:
+      """
+      001.xml
+      """
+    And STDERR should be empty
+
+    When I run `cat 000.xml`
+    Then STDOUT should contain:
+      """
+      <wp:category>
+      """
+    And STDOUT should contain:
+      """
+      <wp:tag>
+      """
+
+    When I run `cat 001.xml`
+    Then STDOUT should not contain:
+      """
+      <wp:category>
+      """
+    And STDOUT should not contain:
+      """
+      <wp:tag>
       """
 
   Scenario: Export without splitting the dump

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -57,6 +57,14 @@ class Export_Command extends WP_CLI_Command {
 	 * default: 15
 	 * ---
 	 *
+	 * [--filename_format=<format>]
+	 * : Use a custom format for export filenames. Defaults to '{site}.wordpress.{date}.{n}.xml'.
+	 *
+	 * [--include_once=<before_posts>]
+	 * : Include specified export section only in the first export file. Valid options
+	 * are categories, tags, nav_menu_items, custom_taxonomies_terms. Separate multiple
+	 * sections with a comma. Defaults to none.
+	 *
 	 * ## FILTERS
 	 *
 	 * [--start_date=<date>]
@@ -97,14 +105,6 @@ class Export_Command extends WP_CLI_Command {
 	 *
 	 * [--post_status=<status>]
 	 * : Export only posts with this status.
-	 *
-	 * [--filename_format=<format>]
-	 * : Use a custom format for export filenames. Defaults to '{site}.wordpress.{date}.{n}.xml'.
-	 *
-	 * [--include_once=<before_posts>]
-	 * : Include specified export section only in the first export file. Valid options
-	 * are categories, tags, nav_menu_items, custom_taxonomies_terms. Separate multiple
-	 * sections with a comma. Defaults to none.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -29,6 +29,7 @@ class Export_Command extends WP_CLI_Command {
 
 	private $stdout;
 	private $max_file_size;
+	private $include_once;
 	private $wxr_path;
 
 	/**
@@ -100,6 +101,11 @@ class Export_Command extends WP_CLI_Command {
 	 * [--filename_format=<format>]
 	 * : Use a custom format for export filenames. Defaults to '{site}.wordpress.{date}.{n}.xml'.
 	 *
+	 * [--include_once=<before_posts>]
+	 * : Include specified export section only in the first export file. Valid options
+	 * are categories, tags, nav_menu_items, custom_taxonomies_terms. Separate multiple
+	 * sections with a comma. Defaults to none.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Export posts published by the user between given start and end date
@@ -138,6 +144,7 @@ class Export_Command extends WP_CLI_Command {
 			'skip_comments'     => null,
 			'max_file_size'     => 15,
 			'filename_format'   => '{site}.wordpress.{date}.{n}.xml',
+			'include_once'      => null,
 		];
 
 		if ( ! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {
@@ -192,6 +199,7 @@ class Export_Command extends WP_CLI_Command {
 							'max_file_size'         => $this->max_file_size,
 							'destination_directory' => $this->wxr_path,
 							'filename_template'     => self::get_filename_template( $assoc_args['filename_format'] ),
+							'include_once'          => $this->include_once,
 						],
 					]
 				);
@@ -463,6 +471,24 @@ class Export_Command extends WP_CLI_Command {
 		}
 
 		$this->max_file_size = $size;
+
+		return true;
+	}
+
+	private function check_include_once( $include_once ) {
+		if ( null === $include_once ) {
+			return true;
+		}
+
+		$separator    = false !== stripos( $include_once, ' ' ) ? ' ' : ',';
+		$include_once = array_filter( array_unique( array_map( 'strtolower', explode( $separator, $include_once ) ) ) );
+		$include_once = array_intersect( $include_once, array( 'categories', 'tags', 'nav_menu_terms', 'custom_taxonomies_terms' ) );
+		if ( empty( $include_once ) ) {
+			WP_CLI::warning( 'include_once should be comma-separated values for optional before_posts sections.' );
+			return false;
+		}
+
+		$this->include_once = $include_once;
 
 		return true;
 	}


### PR DESCRIPTION
Props @jmdodd 

Originally https://github.com/wp-cli/export-command/pull/91

Fixes https://github.com/wp-cli/export-command/issues/76