### PR TITLE
Update `post__in` documentation

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -238,6 +238,39 @@ Feature: Export content.
       """
 
   @require-wp-5.2
+  Scenario: Export multiple posts, separated by comma
+    Given a WP install
+
+    When I run `wp plugin install wordpress-importer --activate`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post create --post_title='Test post' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp post create --post_title='Test post 2' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID_TWO}
+
+    When I run `wp export --post__in="{POST_ID},{POST_ID_TWO}"`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp import {EXPORT_FILE} --authors=skip`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+  @require-wp-5.2
   Scenario: Export posts within a given date range
     Given a WP install
 

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -85,7 +85,7 @@ class Export_Command extends WP_CLI_Command {
 	 * with a comma. Defaults to none.
 	 *
 	 * [--post__in=<pid>]
-	 * : Export all posts specified as a comma- or space-separated list of IDs.
+	 * : Export all posts specified as a comma-separated or space-separated list of IDs.
 	 * Post's attachments won't be exported unless --with_attachments is specified.
 	 *
 	 * [--with_attachments]

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -345,7 +345,7 @@ class Export_Command extends WP_CLI_Command {
 		$separator = false !== stripos( $post__in, ' ' ) ? ' ' : ',';
 		$post__in  = array_filter( array_unique( array_map( 'intval', explode( $separator, $post__in ) ) ) );
 		if ( empty( $post__in ) ) {
-			WP_CLI::warning( 'post__in should be comma-separated post IDs.' );
+			WP_CLI::warning( 'post__in should be comma-separated or space-separated post IDs.' );
 			return false;
 		}
 		// New exporter uses a different argument.


### PR DESCRIPTION
Hello

While investigating #65, I noticed that the `post__in` filter documentation/warning was missing that we can also use a space-separated list of IDs. So, I've updated the docs to reflect that.

Also, I've added a functional test to test exporting multiple posts separated by comma (there is only a functional test to the scenario separated by space).

WP Profile: https://profiles.wordpress.org/rahmohn/
