### PR TITLE
Allow orphan terms to be exported with `--allow_orphan_terms` flag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,8 @@
 # WordPress Coding Standards
 # https://make.wordpress.org/core/handbook/coding-standards/
 
+# From https://github.com/WordPress/wordpress-develop/blob/trunk/.editorconfig with a couple of additions.
+
 root = true
 
 [*]
@@ -13,13 +15,12 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[{.jshintrc,*.json,*.yml,*.feature}]
+[{*.yml,*.feature,.jshintrc,*.json}]
 indent_style = space
 indent_size = 2
 
+[*.md]
+trim_trailing_whitespace = false
+
 [{*.txt,wp-config-sample.php}]
 end_of_line = crlf
-
-[composer.json]
-indent_style = space
-indent_size = 4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 ## Using
 
 ~~~
-wp export [--dir=<dirname>] [--stdout] [--skip_comments] [--max_file_size=<MB>] [--filename_format=<format>] [--include_once=<before_posts>] [--start_date=<date>] [--end_date=<date>] [--post_type=<post-type>] [--post_type__not_in=<post-type>] [--post__in=<pid>] [--with_attachments] [--start_id=<pid>] [--max_num_posts=<num>] [--author=<author>] [--category=<name|id>] [--post_status=<status>]
+wp export [--dir=<dirname>] [--stdout] [--skip_comments] [--max_file_size=<MB>] [--filename_format=<format>] [--include_once=<before_posts>] [--allow_orphan_terms] [--start_date=<date>] [--end_date=<date>] [--post_type=<post-type>] [--post_type__not_in=<post-type>] [--post__in=<pid>] [--with_attachments] [--start_id=<pid>] [--max_num_posts=<num>] [--author=<author>] [--category=<name|id>] [--post_status=<status>]
 ~~~
 
 Generates one or more WXR files containing authors, terms, posts,
@@ -44,7 +44,7 @@ comments, and attachments. WXR files do not include site configuration
 		sections with a comma. Defaults to none.
 
 	[--allow_orphan_terms]
-		Ignore orphaned terms and set parent_id to 0 instead of throwing an exception.
+		Export orphaned terms with `parent=0`, instead of throwing an exception.
 
 **FILTERS**
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ comments, and attachments. WXR files do not include site configuration
 		are categories, tags, nav_menu_items, custom_taxonomies_terms. Separate multiple
 		sections with a comma. Defaults to none.
 
+	[--allow_orphan_terms]
+		Ignore orphaned terms and set parent_id to 0 instead of throwing an exception.
+
 **FILTERS**
 
 	[--start_date=<date>]

--- a/features/export.feature
+++ b/features/export.feature
@@ -1149,6 +1149,7 @@ Feature: Export content.
       Test User
       """
 
+  @require-wp-5.2
   Scenario: Allow export to proceed when orphaned terms are found
     Given a WP install
     And I run `wp term create category orphan --parent=1`

--- a/features/export.feature
+++ b/features/export.feature
@@ -1197,6 +1197,12 @@ Feature: Export content.
       {EXPORT_CATEGORY_PARENT_ID}
       """
 
+    When I run `wp term get category orphan --by=slug --field=parent`
+    Then STDOUT should be:
+      """
+      0
+      """
+
   Scenario: Throw exception when orphaned terms are found
     Given a WP install
     And I run `wp term create category orphan --parent=1`

--- a/features/export.feature
+++ b/features/export.feature
@@ -1165,6 +1165,10 @@ Feature: Export content.
       """
       <wp:category_nicename>orphan</wp:category_nicename>
       """
+    And the {EXPORT_FILE} file should contain:
+      """
+      <wp:tag_slug>atag</wp:tag_slug>
+      """
 
     When I run `wp site empty --yes`
     And I run `wp plugin install wordpress-importer --activate`

--- a/features/export.feature
+++ b/features/export.feature
@@ -1148,3 +1148,26 @@ Feature: Export content.
       """
       Test User
       """
+
+  Scenario: Allow export to proceed when orphaned terms are found
+    Given a WP install
+    And I run `wp term create category orphan --parent=1`
+    And I run `wp db query "DELETE FROM wp_terms WHERE term_id = 1"`
+
+    When I run `wp export --allow_orphan_terms`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    Then the {EXPORT_FILE} file should contain:
+      """
+      <wp:category_nicename>orphan</wp:category_nicename>
+      """
+
+  Scenario: Throw exception when orphaned terms are found
+    Given a WP install
+    And I run `wp term create category orphan --parent=1`
+    And I run `wp db query "DELETE FROM wp_terms WHERE term_id = 1"`
+
+    When I try `wp export`
+    Then STDERR should contain:
+      """
+      Error: Term is missing a parent
+      """

--- a/features/export.feature
+++ b/features/export.feature
@@ -996,6 +996,10 @@ Feature: Export content.
     Then STDOUT should be a number
     And save STDOUT as {EXPORT_CATEGORY_ID}
 
+    When I run `wp term create category National --parent={EXPORT_CATEGORY_ID} --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {EXPORT_SUBCATEGORY_ID}
+
     When I run `wp term create post_tag Tech --description="Technology-related" --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {EXPORT_TAG_ID}
@@ -1027,6 +1031,10 @@ Feature: Export content.
     And the {EXPORT_FILE} file should contain:
       """
       <wp:term_id>{EXPORT_CATEGORY_ID}</wp:term_id>
+      """
+    And the {EXPORT_FILE} file should contain:
+      """
+      <wp:category_parent>news</wp:category_parent>
       """
     And the {EXPORT_FILE} file should contain:
       """
@@ -1103,6 +1111,20 @@ Feature: Export content.
     Then STDOUT should contain:
       """
       News
+      """
+    And STDOUT should contain:
+      """
+      National
+      """
+
+    When I run `wp term get category news --by=slug --field=id`
+    Then STDOUT should be a number
+    And save STDOUT as {IMPORT_CATEGORY_ID}
+
+    When I run `wp term get category national --by=slug --field=parent`
+    Then STDOUT should be:
+      """
+      {IMPORT_CATEGORY_ID}
       """
 
     When I run `wp term list post_tag`

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -148,7 +148,7 @@ class Export_Command extends WP_CLI_Command {
 			'max_file_size'      => 15,
 			'filename_format'    => '{site}.wordpress.{date}.{n}.xml',
 			'include_once'       => null,
-			'allow_orphan_terms' => null
+			'allow_orphan_terms' => null,
 		];
 
 		if ( ! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -65,6 +65,9 @@ class Export_Command extends WP_CLI_Command {
 	 * are categories, tags, nav_menu_items, custom_taxonomies_terms. Separate multiple
 	 * sections with a comma. Defaults to none.
 	 *
+	 * [--allow_orphan_terms]
+	 * : Don't throw an exception when orphaned terms are found.
+	 *
 	 * ## FILTERS
 	 *
 	 * [--start_date=<date>]
@@ -128,23 +131,24 @@ class Export_Command extends WP_CLI_Command {
 	 */
 	public function __invoke( $_, $assoc_args ) {
 		$defaults = [
-			'dir'               => null,
-			'stdout'            => false,
-			'start_date'        => null,
-			'end_date'          => null,
-			'post_type'         => null,
-			'post_type__not_in' => null,
-			'max_num_posts'     => null,
-			'author'            => null,
-			'category'          => null,
-			'post_status'       => null,
-			'post__in'          => null,
-			'with_attachments'  => true, // or FALSE if user requested some post__in
-			'start_id'          => null,
-			'skip_comments'     => null,
-			'max_file_size'     => 15,
-			'filename_format'   => '{site}.wordpress.{date}.{n}.xml',
-			'include_once'      => null,
+			'dir'                => null,
+			'stdout'             => false,
+			'start_date'         => null,
+			'end_date'           => null,
+			'post_type'          => null,
+			'post_type__not_in'  => null,
+			'max_num_posts'      => null,
+			'author'             => null,
+			'category'           => null,
+			'post_status'        => null,
+			'post__in'           => null,
+			'with_attachments'   => true, // or FALSE if user requested some post__in
+			'start_id'           => null,
+			'skip_comments'      => null,
+			'max_file_size'      => 15,
+			'filename_format'    => '{site}.wordpress.{date}.{n}.xml',
+			'include_once'       => null,
+			'allow_orphan_terms' => null
 		];
 
 		if ( ! empty( $assoc_args['stdout'] ) && ( ! empty( $assoc_args['dir'] ) || ! empty( $assoc_args['filename_format'] ) ) ) {
@@ -490,6 +494,19 @@ class Export_Command extends WP_CLI_Command {
 
 		$this->include_once = $include_once;
 
+		return true;
+	}
+
+	private function check_allow_orphan_terms( $allow_orphan_terms ) {
+		if ( null === $allow_orphan_terms ) {
+			return true;
+		}
+
+		if ( 0 !== (int) $allow_orphan_terms && 1 !== (int) $allow_orphan_terms ) {
+			WP_CLI::warning( 'allow_orphan_terms needs to be 0 (no) or 1 (yes).' );
+			return false;
+		}
+		$this->export_args['allow_orphan_terms'] = $allow_orphan_terms;
 		return true;
 	}
 }

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -66,7 +66,7 @@ class Export_Command extends WP_CLI_Command {
 	 * sections with a comma. Defaults to none.
 	 *
 	 * [--allow_orphan_terms]
-	 * : Don't throw an exception when orphaned terms are found.
+	 * : Export orphaned terms with `parent=0`, instead of throwing an exception.
 	 *
 	 * ## FILTERS
 	 *

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -380,6 +380,10 @@ class WP_Export_Query {
 			}
 		}
 
+		if ( ! $this->filters['allow_orphan_terms'] ) {
+			return $terms;
+		}
+
 		if ( count( $orphans ) > 0 ) {
 			$terms_return = [];
 			foreach ( $terms as $term ) {

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -11,15 +11,16 @@ class WP_Export_Query {
 	const QUERY_CHUNK = 100;
 
 	private static $defaults = [
-		'post_ids'      => null,
-		'post_type'     => null,
-		'status'        => null,
-		'author'        => null,
-		'start_date'    => null,
-		'end_date'      => null,
-		'start_id'      => null,
-		'max_num_posts' => null,
-		'category'      => null,
+		'post_ids'           => null,
+		'post_type'          => null,
+		'status'             => null,
+		'author'             => null,
+		'start_date'         => null,
+		'end_date'           => null,
+		'start_id'           => null,
+		'max_num_posts'      => null,
+		'category'           => null,
+		'allow_orphan_terms' => null
 	];
 
 	private $post_ids;
@@ -97,7 +98,7 @@ class WP_Export_Query {
 		}
 		$categories = (array) get_categories( [ 'get' => 'all' ] );
 
-		$this->check_for_orphaned_terms( $categories );
+		$categories = $this->process_orphaned_terms( $categories );
 
 		$categories = self::topologically_sort_terms( $categories );
 
@@ -110,7 +111,7 @@ class WP_Export_Query {
 		}
 		$tags = (array) get_tags( [ 'get' => 'all' ] );
 
-		$this->check_for_orphaned_terms( $tags );
+		$tags = $this->process_orphaned_terms( $tags );
 
 		return $tags;
 	}
@@ -121,7 +122,7 @@ class WP_Export_Query {
 		}
 		$custom_taxonomies = get_taxonomies( [ '_builtin' => false ] );
 		$custom_terms      = (array) get_terms( $custom_taxonomies, [ 'get' => 'all' ] );
-		$this->check_for_orphaned_terms( $custom_terms );
+		$custom_terms = $this->process_orphaned_terms( $custom_terms );
 		$custom_terms = self::topologically_sort_terms( $custom_terms );
 		return $custom_terms;
 	}
@@ -355,9 +356,11 @@ class WP_Export_Query {
 		return $sorted;
 	}
 
-	private function check_for_orphaned_terms( $terms ) {
+	private function process_orphaned_terms( $terms ) {
+
 		$term_ids    = [];
 		$have_parent = [];
+		$orphans     = [];
 
 		foreach ( $terms as $term ) {
 			$term_ids[ $term->term_id ] = true;
@@ -368,10 +371,26 @@ class WP_Export_Query {
 
 		foreach ( $have_parent as $has_parent ) {
 			if ( ! isset( $term_ids[ $has_parent->parent ] ) ) {
-				$this->missing_parents = $has_parent;
-				throw new WP_Export_Term_Exception( "Term is missing a parent: {$has_parent->slug} ({$has_parent->term_taxonomy_id})" );
+				if ( $this->filters['allow_orphan_terms'] ) {
+					$orphans[ $has_parent->term_id ] = true;
+				} else {
+					$this->missing_parents = $has_parent;
+					throw new WP_Export_Term_Exception( "Term is missing a parent: {$has_parent->slug} ({$has_parent->term_taxonomy_id})" );
+				}
 			}
 		}
+
+		if ( count( $orphans ) > 0 ) {
+			$terms_return = [];
+			foreach ( $terms as $term ) {
+				if ( isset( $orphans[ $term->term_id ] ) ) {
+					$term->parent = 0;
+				}
+				$terms_return[] = $term;
+			}
+			$terms = $terms_return;
+		}
+		return $terms;
 	}
 
 	private static function get_terms_for_post( $post ) {

--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -20,7 +20,7 @@ class WP_Export_Query {
 		'start_id'           => null,
 		'max_num_posts'      => null,
 		'category'           => null,
-		'allow_orphan_terms' => null
+		'allow_orphan_terms' => null,
 	];
 
 	private $post_ids;
@@ -122,8 +122,8 @@ class WP_Export_Query {
 		}
 		$custom_taxonomies = get_taxonomies( [ '_builtin' => false ] );
 		$custom_terms      = (array) get_terms( $custom_taxonomies, [ 'get' => 'all' ] );
-		$custom_terms = $this->process_orphaned_terms( $custom_terms );
-		$custom_terms = self::topologically_sort_terms( $custom_terms );
+		$custom_terms      = $this->process_orphaned_terms( $custom_terms );
+		$custom_terms      = self::topologically_sort_terms( $custom_terms );
 		return $custom_terms;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/export-command/issues/108

This PR adds a flag `--allow_orphan_terms`, that when set allows the export to proceed when orphan terms are found.

When the flag is set, the orphaned terms have their parent set to 0 and the export proceeds.

When the flag is not set, an exception is thrown and the export fails.

Related https://github.com/wp-cli/wp-cli/issues/5832