### PR TITLE
Add --skip_authors and --skip_terms as additional flags

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -1236,3 +1236,31 @@ Feature: Export content.
       """
       Error: Term is missing a parent
       """
+
+  Scenario: Export a site and skip the authors
+    Given a WP install
+
+    When I run `wp export --skip_authors`
+    Then save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <wp:author>
+      """
+
+  Scenario: Export a site and skip the terms
+    Given a WP install
+
+    When I run `wp export --skip_terms`
+    Then save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <wp:term>
+      """
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <wp:category>
+      """
+    And the {EXPORT_FILE} file should not contain:
+      """
+      <wp:tags>
+      """

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -195,10 +195,7 @@ class Export_Command extends WP_CLI_Command {
 		}
 
 		if ( $this->export_args['skip_terms'] ) {
-			$this->exclude[] = 'categories';
-			$this->exclude[] = 'tags';
-			$this->exclude[] = 'custom_taxonomies_terms';
-			$this->exclude[] = 'nav_menu_terms';
+			$this->exclude = array_merge( $this->exclude, array( 'categories', 'tags', 'nav_menu_terms', 'custom_taxonomies_terms' ) );
 		}
 
 		if ( ! function_exists( 'wp_export' ) ) {

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -31,6 +31,7 @@ class Export_Command extends WP_CLI_Command {
 	private $max_file_size;
 	private $include_once;
 	private $wxr_path;
+	private $exclude = [];
 
 	/**
 	 * Exports WordPress content to a WXR file.
@@ -49,6 +50,12 @@ class Export_Command extends WP_CLI_Command {
 	 * : Output the whole XML using standard output (incompatible with --dir=)
 	 *
 	 * [--skip_comments]
+	 * : Don't include comments in the WXR export file.
+	 *
+	 * [--skip_authors]
+	 * : Don't include comments in the WXR export file.
+	 *
+	 * [--skip_terms]
 	 * : Don't include comments in the WXR export file.
 	 *
 	 * [--max_file_size=<MB>]
@@ -145,6 +152,8 @@ class Export_Command extends WP_CLI_Command {
 			'with_attachments'   => true, // or FALSE if user requested some post__in
 			'start_id'           => null,
 			'skip_comments'      => null,
+			'skip_authors'       => null,
+			'skip_terms'         => null,
 			'max_file_size'      => 15,
 			'filename_format'    => '{site}.wordpress.{date}.{n}.xml',
 			'include_once'       => null,
@@ -168,6 +177,17 @@ class Export_Command extends WP_CLI_Command {
 			'with_attachments',
 			$defaults['with_attachments']
 		);
+
+		if ( $this->export_args['skip_authors'] ) {
+			$this->exclude[] = 'authors';
+		}
+
+		if ( $this->export_args['skip_terms'] ) {
+			$this->exclude[] = 'categories';
+			$this->exclude[] = 'tags';
+			$this->exclude[] = 'custom_taxonomies_terms';
+			$this->exclude[] = 'nav_menu_terms';
+		}
 
 		if ( ! function_exists( 'wp_export' ) ) {
 			self::load_export_api();
@@ -204,6 +224,7 @@ class Export_Command extends WP_CLI_Command {
 							'destination_directory' => $this->wxr_path,
 							'filename_template'     => self::get_filename_template( $assoc_args['filename_format'] ),
 							'include_once'          => $this->include_once,
+							'exclude'               => $this->exclude,
 						],
 					]
 				);
@@ -465,6 +486,32 @@ class Export_Command extends WP_CLI_Command {
 			return false;
 		}
 		$this->export_args['skip_comments'] = $skip;
+		return true;
+	}
+
+	private function check_skip_authors( $skip ) {
+		if ( null === $skip ) {
+			return true;
+		}
+
+		if ( 0 !== (int) $skip && 1 !== (int) $skip ) {
+			WP_CLI::warning( 'skip_authors needs to be 0 (no) or 1 (yes).' );
+			return false;
+		}
+		$this->export_args['skip_authors'] = $skip;
+		return true;
+	}
+
+	private function check_skip_terms( $skip ) {
+		if ( null === $skip ) {
+			return true;
+		}
+
+		if ( 0 !== (int) $skip && 1 !== (int) $skip ) {
+			WP_CLI::warning( 'skip_terms needs to be 0 (no) or 1 (yes).' );
+			return false;
+		}
+		$this->export_args['skip_terms'] = $skip;
 		return true;
 	}
 

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -53,10 +53,10 @@ class Export_Command extends WP_CLI_Command {
 	 * : Don't include comments in the WXR export file.
 	 *
 	 * [--skip_authors]
-	 * : Don't include comments in the WXR export file.
+	 * : Don't include authors in the WXR export file.
 	 *
 	 * [--skip_terms]
-	 * : Don't include comments in the WXR export file.
+	 * : Don't include terms (categories, tags, custom taxonomy terms and nav menu terms) in the WXR export file.
 	 *
 	 * [--max_file_size=<MB>]
 	 * : A single export file should have this many megabytes. -1 for unlimited.
@@ -176,6 +176,18 @@ class Export_Command extends WP_CLI_Command {
 			$assoc_args,
 			'with_attachments',
 			$defaults['with_attachments']
+		);
+
+		$this->export_args['skip_authors'] = Utils\get_flag_value(
+			$assoc_args,
+			'skip_authors',
+			$defaults['skip_authors']
+		);
+
+		$this->export_args['skip_terms'] = Utils\get_flag_value(
+			$assoc_args,
+			'skip_terms',
+			$defaults['skip_terms']
 		);
 
 		if ( $this->export_args['skip_authors'] ) {

--- a/src/WP_Export_Split_Files_Writer.php
+++ b/src/WP_Export_Split_Files_Writer.php
@@ -45,9 +45,16 @@ class WP_Export_Split_Files_Writer extends WP_Export_Base_Writer {
 			$this->subsequent_sections = array_diff( $this->available_sections, $writer_args['include_once'] );
 		}
 
+		foreach ( $writer_args['exclude'] as $exclude ) {
+			$key = array_search( $exclude, $this->available_sections );
+			if ( false !== $key ) {
+				unset( $this->available_sections[ $key ] );
+			}
+		}
+
 		$this->destination_directory = $writer_args['destination_directory'];
 		$this->filename_template     = $writer_args['filename_template'];
-		$this->before_posts_xml      = $this->formatter->before_posts();
+		$this->before_posts_xml      = $this->formatter->before_posts( $this->available_sections );
 		$this->after_posts_xml       = $this->formatter->after_posts();
 	}
 


### PR DESCRIPTION
This PR introduces `--skip_authors`  and `--skip_terms` flags for `wp export` command.


Fixes: #72 