### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "nb/oxymel": "~0.1.0",
-        "wp-cli/wp-cli": "^2.5"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",

--- a/src/WP_Map_Iterator.php
+++ b/src/WP_Map_Iterator.php
@@ -6,6 +6,7 @@ class WP_Map_Iterator extends IteratorIterator {
 		parent::__construct( $iterator );
 	}
 
+	#[\ReturnTypeWillChange]
 	public function current() {
 		$original_current = parent::current();
 		return call_user_func( $this->callback, $original_current );


### PR DESCRIPTION
For improved PHP 8.4 compatibility.