### PR TITLE
Use get_post_stati() instead of get_post_statuses() to support all registered post statuses in export

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -1239,3 +1239,56 @@ Feature: Export content.
       """
       Error: Term is missing a parent
       """
+
+  @require-wp-5.2 @require-mysql
+  Scenario: Export posts with future status
+    Given a WP install
+    And I run `wp plugin install wordpress-importer --activate`
+    And I run `wp site empty --yes`
+
+    When I run `wp post create --post_title='Future Post 1' --post_status=future --post_date='2050-01-01 12:00:00' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {FUTURE_POST_1}
+
+    When I run `wp post create --post_title='Future Post 2' --post_status=future --post_date='2050-01-02 12:00:00' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {FUTURE_POST_2}
+
+    When I run `wp post list --post_status=future --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp export --post_type=post --post_status=future`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    Then the {EXPORT_FILE} file should contain:
+      """
+      <wp:post_id>{FUTURE_POST_1}</wp:post_id>
+      """
+    And the {EXPORT_FILE} file should contain:
+      """
+      <wp:status>future</wp:status>
+      """
+    And the {EXPORT_FILE} file should contain:
+      """
+      <wp:post_date>2050-01-01 12:00:00</wp:post_date>
+      """
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_status=future --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp import {EXPORT_FILE} --authors=skip`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_status=future --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/src/Export_Command.php
+++ b/src/Export_Command.php
@@ -441,7 +441,7 @@ class Export_Command extends WP_CLI_Command {
 			return true;
 		}
 
-		$stati = get_post_statuses();
+		$stati = get_post_stati();
 		if ( empty( $stati ) || is_wp_error( $stati ) ) {
 			WP_CLI::warning( 'Could not find any post stati.' );
 			return false;


### PR DESCRIPTION
Fixes #120

When using the export command, only posts with statuses returned by get_post_statuses() (publish, pending, draft, private) can be exported. This excludes other valid WordPress post statuses like 'future' for scheduled posts and any custom post statuses.

**Proposed changes**

- Replaced get_post_statuses() with get_post_stati() in the export command
- This change allows exporting posts with any status that is registered in WordPress