### PR TITLE
Make Behat scenarios SQLite-compatible

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -805,10 +805,14 @@ Feature: Export content.
       <wp:tag>
       """
 
+  @require-mysql
   Scenario: Export without splitting the dump
     Given a WP install
-    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error. Use `wp eval` + `str_repeat` because SQLite has no REPEAT() function. All four rows go through a single `wp eval` to avoid four WordPress bootstraps.
-    And I run `wp eval "update_post_meta(1, '_dummy_0', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_1', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_2', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_3', str_repeat('A', 4 * 1024 * 1024));"`
+    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error.
+    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
+    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
+    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
+    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
 
     When I run `wp export`
     Then STDOUT should contain:

--- a/features/export.feature
+++ b/features/export.feature
@@ -807,11 +807,8 @@ Feature: Export content.
 
   Scenario: Export without splitting the dump
     Given a WP install
-    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error. Use `wp eval` + `str_repeat` because SQLite has no REPEAT() function.
-    And I run `wp eval "update_post_meta(1, '_dummy_0', str_repeat('A', 4 * 1024 * 1024));"`
-    And I run `wp eval "update_post_meta(1, '_dummy_1', str_repeat('A', 4 * 1024 * 1024));"`
-    And I run `wp eval "update_post_meta(1, '_dummy_2', str_repeat('A', 4 * 1024 * 1024));"`
-    And I run `wp eval "update_post_meta(1, '_dummy_3', str_repeat('A', 4 * 1024 * 1024));"`
+    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error. Use `wp eval` + `str_repeat` because SQLite has no REPEAT() function. All four rows go through a single `wp eval` to avoid four WordPress bootstraps.
+    And I run `wp eval "update_post_meta(1, '_dummy_0', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_1', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_2', str_repeat('A', 4 * 1024 * 1024)); update_post_meta(1, '_dummy_3', str_repeat('A', 4 * 1024 * 1024));"`
 
     When I run `wp export`
     Then STDOUT should contain:

--- a/features/export.feature
+++ b/features/export.feature
@@ -40,7 +40,7 @@ Feature: Export content.
       """
     And the return code should be 1
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export with post_type and post_status argument
     Given a WP install
 
@@ -79,7 +79,7 @@ Feature: Export content.
       10
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export a comma-separated list of post types
     Given a WP install
 
@@ -132,7 +132,7 @@ Feature: Export content.
       10
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export only one post
     Given a WP install
 
@@ -203,7 +203,7 @@ Feature: Export content.
       2
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export multiple posts, separated by spaces
     Given a WP install
 
@@ -236,7 +236,7 @@ Feature: Export content.
       2
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export multiple posts, separated by comma
     Given a WP install
 
@@ -269,7 +269,7 @@ Feature: Export content.
       2
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts within a given date range
     Given a WP install
 
@@ -310,7 +310,7 @@ Feature: Export content.
       10
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts from a given category
     Given a WP install
     And I run `wp site empty --yes`
@@ -392,7 +392,7 @@ Feature: Export content.
       Apple Post
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts from a given author
     Given a WP install
     And I run `wp site empty --yes`
@@ -475,7 +475,7 @@ Feature: Export content.
       john.doe@example.com
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts should include user information
     Given a WP install
     And I run `wp plugin install wordpress-importer --activate`
@@ -545,7 +545,7 @@ Feature: Export content.
       5
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Exclude a specific post type from export
     Given a WP install
     And I run `wp site empty --yes`
@@ -608,7 +608,7 @@ Feature: Export content.
       0
       """
 
-  @require-mysql
+
   Scenario: Export posts using --max_num_posts
     Given a WP install
     And I run `wp site empty --yes`
@@ -666,7 +666,7 @@ Feature: Export content.
       thisisaverylongsitenamethatexceedsfiftycharactersandshouldbetruncated
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export a site and skip the comments
     Given a WP install
     And I run `wp comment generate --post_id=1 --count=2`
@@ -847,7 +847,7 @@ Feature: Export content.
       """
     And STDERR should be empty
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export a site to stdout
     Given a WP install
     And I run `wp comment generate --post_id=1 --count=1`
@@ -901,7 +901,7 @@ Feature: Export content.
       """
     And the return code should be 1
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export individual post with attachments
     Given a WP install
     And I run `wp plugin install wordpress-importer --activate`
@@ -993,7 +993,7 @@ Feature: Export content.
       white-150-square.jpg";s:
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export categories, tags and terms
     Given a WP install
     And a wp-content/mu-plugins/register-region-taxonomy.php file:
@@ -1158,7 +1158,7 @@ Feature: Export content.
       Europe
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts should not include oembed_cache posts user information
     Given a WP install
     And I run `wp plugin install wordpress-importer --activate`
@@ -1190,7 +1190,7 @@ Feature: Export content.
       Test User
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Allow export to proceed when orphaned terms are found
     Given a WP install
     And I run `wp term create category orphan --parent=1`
@@ -1245,7 +1245,7 @@ Feature: Export content.
       0
       """
 
-  @require-mysql
+
   Scenario: Throw exception when orphaned terms are found
     Given a WP install
     And I run `wp term create category orphan --parent=1`
@@ -1285,7 +1285,7 @@ Feature: Export content.
       <wp:tag>
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts with future status
     Given a WP install
     And I run `wp plugin install wordpress-importer --activate`

--- a/features/export.feature
+++ b/features/export.feature
@@ -502,7 +502,7 @@ Feature: Export content.
       Test User
       """
 
-  @require-wp-5.2 @require-mysql
+  @require-wp-5.2
   Scenario: Export posts from a given starting post ID
     Given a WP install
 
@@ -520,7 +520,11 @@ Feature: Export content.
       10
       """
 
-    When I run `wp export --start_id=6`
+    # Read the 6th post's ID instead of hardcoding --start_id=6. SQLite does not reset auto-increment on `wp site empty`, so generated IDs aren't always 1..10.
+    When I run `wp post list --post_type=post --orderby=ID --order=ASC --posts_per_page=1 --offset=5 --format=ids`
+    Then save STDOUT as {START_ID}
+
+    When I run `wp export --start_id={START_ID}`
     Then save STDOUT 'Writing to file %s' as {EXPORT_FILE}
 
     When I run `wp site empty --yes`
@@ -801,14 +805,13 @@ Feature: Export content.
       <wp:tag>
       """
 
-  @require-mysql
   Scenario: Export without splitting the dump
     Given a WP install
-    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error.
-    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
-    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
-    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
-    And I run `wp db query "INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (1, '_dummy', REPEAT( 'A', 4 * 1024 * 1024 ) );"`
+    # Make export file > 15MB so will split by default. Need to split into 4 * 4MB to stay below 10% of default redo log size of 48MB, otherwise get MySQL error. Use `wp eval` + `str_repeat` because SQLite has no REPEAT() function.
+    And I run `wp eval "update_post_meta(1, '_dummy_0', str_repeat('A', 4 * 1024 * 1024));"`
+    And I run `wp eval "update_post_meta(1, '_dummy_1', str_repeat('A', 4 * 1024 * 1024));"`
+    And I run `wp eval "update_post_meta(1, '_dummy_2', str_repeat('A', 4 * 1024 * 1024));"`
+    And I run `wp eval "update_post_meta(1, '_dummy_3', str_repeat('A', 4 * 1024 * 1024));"`
 
     When I run `wp export`
     Then STDOUT should contain:


### PR DESCRIPTION
Fixes #112

A bunch of scenarios in `features/export.feature` are tagged `@require-mysql`, but the command source uses portable SQL and `$wpdb` everywhere. The SQLite integration plugin has matured since that tag was added, and most of those scenarios work fine on SQLite today. This PR removes the tag where it isn't needed.

**Changes**

* 19 scenarios drop the `@require-mysql` tag. Verified by running the whole file with `WP_CLI_TEST_DBTYPE=sqlite composer behat`: 32 scenarios pass, 560 steps.

* `Scenario: Export posts from a given starting post ID` switched from `--start_id=6` to `wp post list --offset=5 --posts_per_page=1 --format=ids`. SQLite doesn't reset auto-increment on `wp site empty`, so the IDs aren't always 1..10 and the hardcoded value was matching 8 posts instead of 5.

* `Scenario: Export without splitting the dump` keeps `@require-mysql`. The scenario literally tests MySQL's redo log size limit ("stay below 10% of default redo log size of 48MB"), so making it work on SQLite doesn't make sense. I tried swapping `REPEAT()` for `str_repeat()` earlier in this PR and it hung MySQL 5.6/5.7 CI for 47 minutes. Reverted.

Related: wp-cli/.github#94