### PR TITLE
Fix deprecated `get_terms` usage

### DIFF
--- a/src/WP_Export_Query.php
+++ b/src/WP_Export_Query.php
@@ -121,10 +121,14 @@ class WP_Export_Query {
 			return [];
 		}
 		$custom_taxonomies = get_taxonomies( [ '_builtin' => false ] );
-		// phpcs:ignore WordPress.WP.DeprecatedParameters.Get_termsParam2Found -- Deprecated, but we need to support older versions of WordPress.
-		$custom_terms = (array) get_terms( $custom_taxonomies, [ 'get' => 'all' ] );
-		$custom_terms = $this->process_orphaned_terms( $custom_terms );
-		$custom_terms = self::topologically_sort_terms( $custom_terms );
+		$custom_terms      = (array) get_terms(
+			[
+				'taxonomy' => $custom_taxonomies,
+				'get'      => 'all',
+			]
+		);
+		$custom_terms      = $this->process_orphaned_terms( $custom_terms );
+		$custom_terms      = self::topologically_sort_terms( $custom_terms );
 		return $custom_terms;
 	}
 


### PR DESCRIPTION
The single arg signature was added in WP 4.5 so it's safe to use that.

Addresses a newly reported PHPStan error.